### PR TITLE
Fix critical issues in facebook-for-woocommerce.php

### DIFF
--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -80,12 +80,13 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 		}
 
 		public function wp_debug_display_error() {
+
 			?>
-	<div class="error below-h3">
-	  <p>
-			<?php esc_html__( 'To use Facebook for WooCommerce, please disable WP_DEBUG_DISPLAY in your wp-config.php file. Contact your server administrator for more assistance.', 'facebook-for-woocommerce' ); ?>
-	  </p>
-	</div>
+			<div class="error below-h3">
+				<p>
+					<?php esc_html__( 'To use Facebook for WooCommerce, please disable WP_DEBUG_DISPLAY in your wp-config.php file. Contact your server administrator for more assistance.', 'facebook-for-woocommerce' ); ?>
+				</p>
+			</div>
 			<?php
 		}
 

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -79,16 +79,6 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 			return array_merge( $settings, $links );
 		}
 
-		public function wp_debug_display_error() {
-
-			?>
-			<div class="error below-h3">
-				<p>
-					<?php esc_html__( 'To use Facebook for WooCommerce, please disable WP_DEBUG_DISPLAY in your wp-config.php file. Contact your server administrator for more assistance.', 'facebook-for-woocommerce' ); ?>
-				</p>
-			</div>
-			<?php
-		}
 
 		/**
 		 * Add a new integration to WooCommerce.

--- a/facebook-for-woocommerce.php
+++ b/facebook-for-woocommerce.php
@@ -83,16 +83,7 @@ if ( ! class_exists( 'WC_Facebookcommerce' ) ) :
 			?>
 	<div class="error below-h3">
 	  <p>
-			<?php
-			printf(
-				__(
-					'To use Facebook for WooCommerce,
-          please disable WP_DEBUG_DISPLAY in your wp-config.php file.
-          Contact your server administrator for more assistance.',
-					'facebook-for-woocommerce'
-				)
-			);
-			?>
+			<?php esc_html__( 'To use Facebook for WooCommerce, please disable WP_DEBUG_DISPLAY in your wp-config.php file. Contact your server administrator for more assistance.', 'facebook-for-woocommerce' ); ?>
 	  </p>
 	</div>
 			<?php


### PR DESCRIPTION
# Summary

This PR fixes a PHPCS issue in `facebook-for-woocommerce.php`.

### Story: [CH 25216](https://app.clubhouse.io/skyverge/story/25216/fix-critical-issues-in-facebook-for-woocommerce-php)
### Release: #1

## Details

While I was trying to test the plugin funcitonality I realized usage for this method was removed in https://github.com/facebookincubator/facebook-for-woocommerce/commit/b6cca13#diff-4d5c2f1400260427f25587f3f480ea82, so I think the solution in this case is to remove the method.

## QA

1. Run `vendor/bin/phpcs --severity=6 facebook-for-woocommerce.php`
    - [x] No issues are reported

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version
