### PR TITLE
Fix critical issues in facebook-commerce-events-tracker.php

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -276,9 +276,12 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		}
 
 		/**
-		 * Triggered by add_to_cart jquery trigger
+		 * Sends a JSON response with the JavaScript code to track an AddToCart event.
+		 *
+		 * Handler for the fb_inject_add_to_cart_event WC Ajax action.
 		 */
 		public function inject_ajax_add_to_cart_event() {
+
 			if ( ! self::$isEnabled ) {
 				return;
 			}

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -108,8 +108,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 
 		/**
-		 * Base pixel noscript to be injected on page body. This is to avoid W3
-		 * validation error.
+		 * Prints the base <noscript> pixel code.
+		 *
+		 * This is necessary to avoid W3 validation errors.
 		 */
 		public function inject_base_pixel_noscript() {
 
@@ -118,6 +119,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				echo $this->pixel->pixel_base_code_noscript();
 			}
 		}
+
 
 		/**
 		 * Triggers ViewCategory for product category listings

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -286,22 +286,19 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				return;
 			}
 
+			$event_params = [
+				'content_ids'  => json_encode( $this->get_content_ids_from_cart( WC()->cart->get_cart() ) ),
+				'content_type' => 'product',
+				'value'        => WC()->cart->total,
+				'currency'     => get_woocommerce_currency(),
+			];
+
 			ob_start();
 
 			echo '<script>';
 
-			$product_ids = $this->get_content_ids_from_cart( WC()->cart->get_cart() );
-
 			// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-			echo $this->pixel->build_event(
-				'AddToCart',
-				array(
-					'content_ids'  => json_encode( $product_ids ),
-					'content_type' => 'product',
-					'value'        => WC()->cart->total,
-					'currency'     => get_woocommerce_currency(),
-				)
-			);
+			echo $this->pixel->build_event( 'AddToCart', $event_params );
 
 			echo '</script>';
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -101,6 +101,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function inject_base_pixel() {
 			if ( self::$isEnabled ) {
+				// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 				echo $this->pixel->pixel_base_code();
 			}
 		}

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -94,17 +94,18 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			);
 		}
 
+
 		/**
-		 * Base pixel code to be injected on page head. Because of this, it's better
-		 * to echo the return value than using
-		 * WC_Facebookcommerce_Utils::wc_enqueue_js() in this case
+		 * Prints the base JavaScript pixel code.
 		 */
 		public function inject_base_pixel() {
+
 			if ( self::$isEnabled ) {
 				// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 				echo $this->pixel->pixel_base_code();
 			}
 		}
+
 
 		/**
 		 * Base pixel noscript to be injected on page body. This is to avoid W3

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -289,6 +289,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 
 			$product_ids = $this->get_content_ids_from_cart( WC()->cart->get_cart() );
 
+			// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 			echo $this->pixel->build_event(
 				'AddToCart',
 				array(
@@ -298,6 +299,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 					'currency'     => get_woocommerce_currency(),
 				)
 			);
+
 			echo '</script>';
 
 			$pixel = ob_get_clean();

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -112,7 +112,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 * validation error.
 		 */
 		public function inject_base_pixel_noscript() {
+
 			if ( self::$isEnabled ) {
+				// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 				echo $this->pixel->pixel_base_code_noscript();
 			}
 		}

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -218,8 +218,8 @@ src="https://www.facebook.com/tr?id=%s&ev=PageView&noscript=1"/>
 				"/* %s Facebook Integration Event Tracking */\n" .
 				"fbq('%s', '%s', %s);",
 				WC_Facebookcommerce_Utils::getIntegrationName(),
-				$method,
-				$event_name,
+				esc_js( $method ),
+				esc_js( $event_name ),
 				json_encode( $params, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT )
 			);
 		}


### PR DESCRIPTION
# Summary

This PR fixes a PHPCS issue in `facebook-commerce-events-tracker.php`.

### Story: [CH 25209](https://app.clubhouse.io/skyverge/story/25209/fix-critical-issues-in-facebook-commerce-events-tracker-php)
### Release: #1

## Details

The issues were all related to echoing JavaScript or HTML code necessary to setup the Facebook pixel, so we shouldn't use escape functions in that case. Instead, we should use escape functions in the methods that generate the corresponding HTML and JavaScript code.

I updated `inject_base_pixel_noscript()` here and added tasks to update other methods in [CH 25214](https://app.clubhouse.io/skyverge/story/25214/fix-critical-issues-in-facebook-commerce-pixel-event-php) (which handles `facebook-commerce-pixel-event.php`).

## QA

### Setup

- Configure Facebook for WooCommerce
- Install the [Facebook Pixel Helper](https://chrome.google.com/webstore/detail/facebook-pixel-helper/fdgfkebogiimcoedlicjlajpkdmockpc) Chrome extension:

### Steps

#### Facebook pixel is setup correctly

1. Go to the home page
    - [x] The pixel is found in the home page.
    - [x] A PageView event is tracked when the page loads
1. Add a product to the cart
    - [x] An AddToCart event is tracked after the item is added to the cart
    - [x] The `content_type`, `content_ids` (products ids using format `wc_post_id_{id}`), `value` (cart total) and `currency` parameters are set

#### PHPCS

1. Run `vendor/bin/phpcs --severity=6 facebook-commerce-events-tracker.php`
    - [x] No issues are reported

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version