### PR TITLE
Fix issues in facebook-commerce-messenger-chat.php 

### DIFF
--- a/facebook-commerce-messenger-chat.php
+++ b/facebook-commerce-messenger-chat.php
@@ -44,6 +44,12 @@ if ( ! class_exists( 'WC_Facebookcommerce_MessengerChat' ) ) :
 			add_action( 'wp_footer', array( $this, 'inject_messenger_chat_plugin' ) );
 		}
 
+
+		/**
+		 * Outputs the Facebook Messenger chat script.
+		 *
+		 * @internal
+		 */
 		public function inject_messenger_chat_plugin() {
 
 			if ( $this->enabled === 'yes' ) :

--- a/facebook-commerce-messenger-chat.php
+++ b/facebook-commerce-messenger-chat.php
@@ -62,7 +62,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_MessengerChat' ) ) :
 						%s
 						%s
 						%s
-					/></div>
+					></div>
 					<!-- Facebook JSSDK -->
 					<script>
 					  window.fbAsyncInit = function() {

--- a/facebook-commerce-messenger-chat.php
+++ b/facebook-commerce-messenger-chat.php
@@ -85,9 +85,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_MessengerChat' ) ) :
 					<div></div>
 					",
 					esc_attr( $this->page_id ),
-					esc_attr( $this->theme_color_code ? sprintf( 'theme_color="%s"', $this->theme_color_code ) : '' ),
-					esc_attr( $this->greeting_text_code ? sprintf( 'logged_in_greeting="%s"', $this->greeting_text_code ) : '' ),
-					esc_attr( $this->greeting_text_code ? sprintf( 'logged_out_greeting="%s"', $this->greeting_text_code ) : '' ),
+					esc_html( $this->theme_color_code   ? sprintf( 'theme_color="%s"', esc_attr( $this->theme_color_code ) ) : '' ),
+					esc_html( $this->greeting_text_code ? sprintf( 'logged_in_greeting="%s"', esc_attr( $this->greeting_text_code ) ) : '' ),
+					esc_html( $this->greeting_text_code ? sprintf( 'logged_out_greeting="%s"', esc_attr( $this->greeting_text_code ) ) : '' ),
 					esc_js( $this->jssdk_version ),
 					esc_js( $this->locale ?: 'en_US' )
 				);

--- a/facebook-commerce-messenger-chat.php
+++ b/facebook-commerce-messenger-chat.php
@@ -45,43 +45,48 @@ if ( ! class_exists( 'WC_Facebookcommerce_MessengerChat' ) ) :
 		}
 
 		public function inject_messenger_chat_plugin() {
-			if ( $this->enabled === 'yes' ) {
-				echo sprintf(
-					"<div
-  attribution=\"fbe_woocommerce\"
-  class=\"fb-customerchat\"
-  page_id=\"%s\"
-  %s
-  %s
-  %s /></div>
-<!-- Facebook JSSDK -->
-<script>
-  window.fbAsyncInit = function() {
-    FB.init({
-      appId            : '',
-      autoLogAppEvents : true,
-      xfbml            : true,
-      version          : '%s'
-    });
-  };
 
-  (function(d, s, id){
-      var js, fjs = d.getElementsByTagName(s)[0];
-      if (d.getElementById(id)) {return;}
-      js = d.createElement(s); js.id = id;
-      js.src = 'https://connect.facebook.net/%s/sdk/xfbml.customerchat.js';
-      fjs.parentNode.insertBefore(js, fjs);
-    }(document, 'script', 'facebook-jssdk'));
-</script>
-<div></div>",
-					$this->page_id,
-					$this->theme_color_code ? sprintf( 'theme_color="%s"', $this->theme_color_code ) : '',
-					$this->greeting_text_code ? sprintf( 'logged_in_greeting="%s"', $this->greeting_text_code ) : '',
-					$this->greeting_text_code ? sprintf( 'logged_out_greeting="%s"', $this->greeting_text_code ) : '',
-					$this->jssdk_version,
-					$this->locale ? $this->locale : 'en_US'
+			if ( $this->enabled === 'yes' ) :
+
+				printf( "
+					<div
+						attribution=\"fbe_woocommerce\"
+						class=\"fb-customerchat\"
+						page_id=\"%s\"
+						%s
+						%s
+						%s
+					/></div>
+					<!-- Facebook JSSDK -->
+					<script>
+					  window.fbAsyncInit = function() {
+					    FB.init({
+					      appId            : '',
+					      autoLogAppEvents : true,
+					      xfbml            : true,
+					      version          : '%s'
+					    });
+					  };
+
+					  (function(d, s, id){
+					      var js, fjs = d.getElementsByTagName(s)[0];
+					      if (d.getElementById(id)) {return;}
+					      js = d.createElement(s); js.id = id;
+					      js.src = 'https://connect.facebook.net/%s/sdk/xfbml.customerchat.js';
+					      fjs.parentNode.insertBefore(js, fjs);
+					    }(document, 'script', 'facebook-jssdk'));
+					</script>
+					<div></div>
+					",
+					esc_attr( $this->page_id ),
+					esc_attr( $this->theme_color_code ? sprintf( 'theme_color="%s"', $this->theme_color_code ) : '' ),
+					esc_attr( $this->greeting_text_code ? sprintf( 'logged_in_greeting="%s"', $this->greeting_text_code ) : '' ),
+					esc_attr( $this->greeting_text_code ? sprintf( 'logged_out_greeting="%s"', $this->greeting_text_code ) : '' ),
+					esc_js( $this->jssdk_version ),
+					esc_js( $this->locale ?: 'en_US' )
 				);
-			}
+
+			endif;
 		}
 
 	}


### PR DESCRIPTION
# Summary

This PR fixes PHPCS issues in `facebook-commerce-messenger-chat.php`.

### Story: [CH 25215](https://app.clubhouse.io/skyverge/story/25215/fix-critical-issues-in-facebook-commerce-messenger-chat-php)
### Release: #1

## Details

The issues were all related to echoing JavaScript or HTML code necessary to setup the Facebook Messenger chat.

The code is a bit off standards and could be probably converted to be more HTML-template like, but for the time being I only inserted the necessary WordPress `esc_` functions so the code is sanely escaped and PHPCS doesn't complain. 

Interestingly, Facebook seems to call this method `inject_messenger_chat_plugin()` as "plugin" because they do run a dedicated [Messenger Chat plugin](https://wordpress.org/plugins/facebook-messenger-customer-chat/), which does pretty much the same thing (I tested it). This seems a bit confusing and one might want to consider renaming in the future, as all it does is to output some HTML and JS code, not a "plugin" in WordPress terms.

## QA

### Setup

- Configure Facebook for WooCommerce
- Configure also the chat (from the same configuration panel, it's an additional entity after you've done with the basic store configuration)

### Steps

#### Facebook Messenger Chat triggers correctly

1. Go to any shop page
    - [x] You can see the Messenger logo on the bottom right corner of the page
    - [x] If you're logged in you can start interacting with the page/site

#### PHPCS

1. Run `vendor/bin/phpcs --severity=6 facebook-commerce-messenger-chat.php`
    - [x] No issues are reported

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version