### PR TITLE
Fix critical issues in facebook-commerce-pixel-event.php

### DIFF
--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -110,11 +110,11 @@ document.addEventListener('DOMContentLoaded', function() {
 <!-- DO NOT MODIFY -->
 <!-- %s Facebook Integration end -->
     ",
-				WC_Facebookcommerce_Utils::getIntegrationName(),
+				esc_html( WC_Facebookcommerce_Utils::getIntegrationName() ),
 				self::get_basecode(),
 				$this->pixel_init_code(),
 				json_encode( $params, JSON_PRETTY_PRINT | JSON_FORCE_OBJECT ),
-				WC_Facebookcommerce_Utils::getIntegrationName()
+				esc_html( WC_Facebookcommerce_Utils::getIntegrationName() )
 			);
 		}
 

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -162,8 +162,18 @@ document.addEventListener('DOMContentLoaded', function() {
 		}
 
 
-		public function inject_conditional_event(
-		$event_name, $params, $listener, $jsonified_pii = '' ) {
+		/**
+		 * Prints the JavaScript code to track a conditional event.
+		 *
+		 * The tracking code will be executed when the given JavaScript event is triggered.
+		 *
+		 * @param string $event_name
+		 * @param array $params custom event parameters
+		 * @param string $listener name of the JavaScript event to listen for
+		 * @param string $jsonified_pii JavaScript code representing an object of data for Advanced Matching
+		 */
+		public function inject_conditional_event( $event_name, $params, $listener, $jsonified_pii = '' ) {
+
 			$code             = self::build_event( $event_name, $params, 'track' );
 			$this->last_event = $event_name;
 
@@ -187,6 +197,7 @@ document.addEventListener('%s', function (event) {
 			// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 			printf( $output, esc_js( $listener ), $code );
 		}
+
 
 		/**
 		 * Returns FB pixel code noscript part to avoid W3 validation error

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -174,8 +174,7 @@ document.addEventListener('DOMContentLoaded', function() {
 				sprintf( $this->pixel_init_code(), '" || ' . $jsonified_pii . ' || "' ) . $code;
 			}
 
-			printf(
-				"
+			$output = "
 <!-- Facebook Pixel Event Code -->
 <script>
 document.addEventListener('%s', function (event) {
@@ -183,10 +182,10 @@ document.addEventListener('%s', function (event) {
 }, false );
 </script>
 <!-- End Facebook Pixel Event Code -->
-      ",
-				$listener,
-				$code
-			);
+";
+
+			// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+			printf( $output, esc_js( $listener ), $code );
 		}
 
 		/**

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -134,18 +134,21 @@ document.addEventListener('DOMContentLoaded', function() {
 			$this->last_event = $event_name;
 
 			if ( WC_Facebookcommerce_Utils::isWoocommerceIntegration() ) {
+
 				WC_Facebookcommerce_Utils::wc_enqueue_js( $code );
+
 			} else {
-				printf(
-					'
+
+				$output = '
 <!-- Facebook Pixel Event Code -->
 <script>
 %s
 </script>
 <!-- End Facebook Pixel Event Code -->
-        ',
-					$code
-				);
+';
+
+				// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+				printf( $output, $code );
 			}
 		}
 

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -204,7 +204,7 @@ src="https://www.facebook.com/tr?id=%s&ev=PageView&noscript=1"/>
 <!-- DO NOT MODIFY -->
 <!-- End Facebook Pixel Code -->
     ',
-				esc_js( $pixel_id )
+				esc_attr( $pixel_id )
 			);
 		}
 

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -177,6 +177,7 @@ document.addEventListener('DOMContentLoaded', function() {
 			$code             = self::build_event( $event_name, $params, 'track' );
 			$this->last_event = $event_name;
 
+			/** TODO: use the settings stored by {@see \WC_Facebookcommerce_Integration}. The use_pii setting here is currently always disabled regardless of the value configured in the plugin settings page {WV-2020-01-02} */
 			// Prepends fbq(...) with pii information to the injected code.
 			if ( $jsonified_pii && get_option( self::SETTINGS_KEY )[ self::USE_PII_KEY ] ) {
 				$this->user_info = '%s';

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -125,11 +125,20 @@ document.addEventListener('DOMContentLoaded', function() {
 			return $event_name === $this->last_event;
 		}
 
+
 		/**
-		 * Preferred method to inject events in a page, normally you should use this
-		 * instead of WC_Facebookcommerce_Pixel::build_event()
+		 * Prints or enqueues the JavaScript code to track an event.
+		 *
+		 * Preferred method to inject events in a page.
+		 *
+		 * @see \WC_Facebookcommerce_Pixel::build_event()
+		 *
+		 * @param string $event_name the name of the event to track
+		 * @param array $params custom event parameters
+		 * @param string $method name of the pixel's fbq() function to call
 		 */
 		public function inject_event( $event_name, $params, $method = 'track' ) {
+
 			$code             = self::build_event( $event_name, $params, $method );
 			$this->last_event = $event_name;
 
@@ -151,6 +160,7 @@ document.addEventListener('DOMContentLoaded', function() {
 				printf( $output, $code );
 			}
 		}
+
 
 		public function inject_conditional_event(
 		$event_name, $params, $listener, $jsonified_pii = '' ) {


### PR DESCRIPTION
# Summary

This PR fixes a PHPCS issue in `facebook-commerce-pixel-event.php`.

### Story: [CH 25214](https://app.clubhouse.io/skyverge/story/25214/fix-critical-issues-in-facebook-commerce-pixel-event-php)
### Release: #1

## Details

The issues were all related to echoing JavaScript code used to track pixel events. I added `esc_attr()` and `esc_html()` where possible, but had to ignore other issues where escaping was not appropriate.

## QA

### Setup

- Configure Facebook for WooCommerce
- Install the [Facebook Pixel Helper](https://chrome.google.com/webstore/detail/facebook-pixel-helper/fdgfkebogiimcoedlicjlajpkdmockpc) Chrome extension:

### Steps

#### Facebook pixel is setup correctly

1. Go to the home page
    - [x] The pixel is found in the home page.
    - [x] A PageView event is tracked when the page loads
1. Add a product to the cart
    - [x] An AddToCart event is tracked after the item is added to the cart
    - [x] The `content_type`, `content_ids` (products ids using format `wc_post_id_{id}`), `value` (cart total) and `currency` parameters are set

#### Facebook pixel tracks Leads

1. Install and activate Contact Form 7
1. Go to Contact > Contact Forms and copy the shortcode for the default form
1. Add the form shortcode to a page
1. Submit the form
    - [x] Facebook Pixel Helper reports a warning about the Lead event when the page loads (that's expected because the event will fire in response to the `wpcf7submit` event)
    - [x] A Lead event is tracked when the form is submitted

#### PHPCS

1. Run `vendor/bin/phpcs --severity=6 facebook-commerce-pixel-event.php`
    - [x] No issues are reported

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version
- [ ] I have copied all UI Changes and QA items listed above into the base release branch PR description