### PR TITLE
Fix critical issues in includes/fbinfobanner.php

### DIFF
--- a/includes/fbinfobanner.php
+++ b/includes/fbinfobanner.php
@@ -204,7 +204,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Info_Banner' ) ) :
 
 			echo '<div class="updated fade">';
 			echo '<div id="fbinfobanner">';
-			echo '<div><img src="' . $tip_img_url . '" class="iconDetails"></div>';
+			echo '<div><img src="' . esc_url( $tip_img_url ) . '" class="iconDetails"></div>';
 			echo '<p class = "tipTitle">' . __( '<strong>' . $tip_title . '</strong>', 'facebook-for-woocommerce' ) . "\n";
 			echo '<p class = "tipContent">' . __( $tip_body, 'facebook-for-woocommerce' ) . '</p>';
 			echo '<p class = "tipButton">';

--- a/includes/fbinfobanner.php
+++ b/includes/fbinfobanner.php
@@ -208,7 +208,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Info_Banner' ) ) :
 			echo '<p class = "tipTitle"><strong>' . esc_html( $tip_title ) . "</strong></p>\n";
 			echo '<p class = "tipContent">' . esc_html( $tip_body ) . '</p>';
 			echo '<p class = "tipButton">';
-			echo '<a href="' . $tip_action_link . '" class = "btn" onclick="fb_woo_infobanner_post_click(); return true;" title="' . __( 'Click and redirect.', 'facebook-for-woocommerce' ) . '"> ' . __( $tip_action, 'facebook-for-woocommerce' ) . '</a>';
+			echo '<a href="' . esc_url( $tip_action_link ) . '" class = "btn" onclick="fb_woo_infobanner_post_click(); return true;" title="' . __( 'Click and redirect.', 'facebook-for-woocommerce' ) . '"> ' . __( $tip_action, 'facebook-for-woocommerce' ) . '</a>';
 			echo '<a href="' . esc_url( $dismiss_url ) . '" class = "btn dismiss grey" onclick="fb_woo_infobanner_post_xout(); return true;" title="' . __( 'Dismiss this notice.', 'facebook-for-woocommerce' ) . '"> ' . __( 'Dismiss', 'facebook-for-woocommerce' ) . '</a>';
 			echo '</p></div></div>';
 		}

--- a/includes/fbinfobanner.php
+++ b/includes/fbinfobanner.php
@@ -208,8 +208,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_Info_Banner' ) ) :
 			echo '<p class = "tipTitle"><strong>' . esc_html( $tip_title ) . "</strong></p>\n";
 			echo '<p class = "tipContent">' . esc_html( $tip_body ) . '</p>';
 			echo '<p class = "tipButton">';
-			echo '<a href="' . esc_url( $tip_action_link ) . '" class = "btn" onclick="fb_woo_infobanner_post_click(); return true;" title="' . esc_attr__( 'Click and redirect.', 'facebook-for-woocommerce' ) . '"> ' . __( $tip_action, 'facebook-for-woocommerce' ) . '</a>';
-			echo '<a href="' . esc_url( $dismiss_url ) . '" class = "btn dismiss grey" onclick="fb_woo_infobanner_post_xout(); return true;" title="' . esc_attr__( 'Dismiss this notice.', 'facebook-for-woocommerce' ) . '"> ' . __( 'Dismiss', 'facebook-for-woocommerce' ) . '</a>';
+			echo '<a href="' . esc_url( $tip_action_link ) . '" class = "btn" onclick="fb_woo_infobanner_post_click(); return true;" title="' . esc_attr__( 'Click and redirect.', 'facebook-for-woocommerce' ) . '"> ' . esc_html( $tip_action ) . '</a>';
+			echo '<a href="' . esc_url( $dismiss_url ) . '" class = "btn dismiss grey" onclick="fb_woo_infobanner_post_xout(); return true;" title="' . esc_attr__( 'Dismiss this notice.', 'facebook-for-woocommerce' ) . '"> ' . esc_html__( 'Dismiss', 'facebook-for-woocommerce' ) . '</a>';
 			echo '</p></div></div>';
 		}
 

--- a/includes/fbinfobanner.php
+++ b/includes/fbinfobanner.php
@@ -205,7 +205,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Info_Banner' ) ) :
 			echo '<div class="updated fade">';
 			echo '<div id="fbinfobanner">';
 			echo '<div><img src="' . esc_url( $tip_img_url ) . '" class="iconDetails"></div>';
-			echo '<p class = "tipTitle">' . __( '<strong>' . $tip_title . '</strong>', 'facebook-for-woocommerce' ) . "\n";
+			echo '<p class = "tipTitle"><strong>' . esc_html( $tip_title ) . "</strong></p>\n";
 			echo '<p class = "tipContent">' . __( $tip_body, 'facebook-for-woocommerce' ) . '</p>';
 			echo '<p class = "tipButton">';
 			echo '<a href="' . $tip_action_link . '" class = "btn" onclick="fb_woo_infobanner_post_click(); return true;" title="' . __( 'Click and redirect.', 'facebook-for-woocommerce' ) . '"> ' . __( $tip_action, 'facebook-for-woocommerce' ) . '</a>';

--- a/includes/fbinfobanner.php
+++ b/includes/fbinfobanner.php
@@ -206,7 +206,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_Info_Banner' ) ) :
 			echo '<div id="fbinfobanner">';
 			echo '<div><img src="' . esc_url( $tip_img_url ) . '" class="iconDetails"></div>';
 			echo '<p class = "tipTitle"><strong>' . esc_html( $tip_title ) . "</strong></p>\n";
-			echo '<p class = "tipContent">' . __( $tip_body, 'facebook-for-woocommerce' ) . '</p>';
+			echo '<p class = "tipContent">' . esc_html( $tip_body ) . '</p>';
 			echo '<p class = "tipButton">';
 			echo '<a href="' . $tip_action_link . '" class = "btn" onclick="fb_woo_infobanner_post_click(); return true;" title="' . __( 'Click and redirect.', 'facebook-for-woocommerce' ) . '"> ' . __( $tip_action, 'facebook-for-woocommerce' ) . '</a>';
 			echo '<a href="' . esc_url( $dismiss_url ) . '" class = "btn dismiss grey" onclick="fb_woo_infobanner_post_xout(); return true;" title="' . __( 'Dismiss this notice.', 'facebook-for-woocommerce' ) . '"> ' . __( 'Dismiss', 'facebook-for-woocommerce' ) . '</a>';

--- a/includes/fbinfobanner.php
+++ b/includes/fbinfobanner.php
@@ -233,11 +233,17 @@ if ( ! class_exists( 'WC_Facebookcommerce_Info_Banner' ) ) :
 			return wp_nonce_url( $url, 'woocommerce_info_banner_dismiss' );
 		}
 
+
 		/**
-		 * Handles the dismiss action so that the banner can be permanently hidden
-		 * during time threshold
+		 * Handles the action that dismisses the info banner.
+		 *
+		 * The banner will remain dismissed for at least one day and until a new info tip can be retrieved.
+		 *
+		 * @see \WC_Facebookcommerce_Integration::FB_TIP_QUERY
+		 * @see \WC_Facebookcommerce_Graph_API::get_tip_info()
 		 */
 		public function dismiss_banner() {
+
 			if ( ! isset( $_GET['wc-notice'] ) ) {
 				return;
 			}
@@ -258,6 +264,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_Info_Banner' ) ) :
 				wp_safe_redirect( admin_url( 'admin.php?page=wc-settings&tab=integration' ) );
 			}
 		}
+
+
 	}
 
 endif;

--- a/includes/fbinfobanner.php
+++ b/includes/fbinfobanner.php
@@ -201,17 +201,16 @@ if ( ! class_exists( 'WC_Facebookcommerce_Info_Banner' ) ) :
 			}
 
 			$dismiss_url = $this->dismiss_url();
-			echo '<div class="updated fade"><div id="fbinfobanner"><div><img src="' . $tip_img_url .
-			'" class="iconDetails"></div><p class = "tipTitle">' .
-			__( '<strong>' . $tip_title . '</strong>', 'facebook-for-woocommerce' ) . "\n";
-			echo '<p class = "tipContent">' .
-			__( $tip_body, 'facebook-for-woocommerce' ) . '</p>';
-			echo '<p class = "tipButton"><a href="' . $tip_action_link . '" class = "btn" onclick="fb_woo_infobanner_post_click(); return true;" title="' .
-			__( 'Click and redirect.', 'facebook-for-woocommerce' ) .
-			'"> ' . __( $tip_action, 'facebook-for-woocommerce' ) . '</a>' .
-			'<a href="' . esc_url( $dismiss_url ) . '" class = "btn dismiss grey" onclick="fb_woo_infobanner_post_xout(); return true;" title="' .
-			__( 'Dismiss this notice.', 'facebook-for-woocommerce' ) .
-			'"> ' . __( 'Dismiss', 'facebook-for-woocommerce' ) . '</a></p></div></div>';
+
+			echo '<div class="updated fade">';
+			echo '<div id="fbinfobanner">';
+			echo '<div><img src="' . $tip_img_url . '" class="iconDetails"></div>';
+			echo '<p class = "tipTitle">' . __( '<strong>' . $tip_title . '</strong>', 'facebook-for-woocommerce' ) . "\n";
+			echo '<p class = "tipContent">' . __( $tip_body, 'facebook-for-woocommerce' ) . '</p>';
+			echo '<p class = "tipButton">';
+			echo '<a href="' . $tip_action_link . '" class = "btn" onclick="fb_woo_infobanner_post_click(); return true;" title="' . __( 'Click and redirect.', 'facebook-for-woocommerce' ) . '"> ' . __( $tip_action, 'facebook-for-woocommerce' ) . '</a>';
+			echo '<a href="' . esc_url( $dismiss_url ) . '" class = "btn dismiss grey" onclick="fb_woo_infobanner_post_xout(); return true;" title="' . __( 'Dismiss this notice.', 'facebook-for-woocommerce' ) . '"> ' . __( 'Dismiss', 'facebook-for-woocommerce' ) . '</a>';
+			echo '</p></div></div>';
 		}
 
 		/**

--- a/includes/fbinfobanner.php
+++ b/includes/fbinfobanner.php
@@ -208,8 +208,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_Info_Banner' ) ) :
 			echo '<p class = "tipTitle"><strong>' . esc_html( $tip_title ) . "</strong></p>\n";
 			echo '<p class = "tipContent">' . esc_html( $tip_body ) . '</p>';
 			echo '<p class = "tipButton">';
-			echo '<a href="' . esc_url( $tip_action_link ) . '" class = "btn" onclick="fb_woo_infobanner_post_click(); return true;" title="' . __( 'Click and redirect.', 'facebook-for-woocommerce' ) . '"> ' . __( $tip_action, 'facebook-for-woocommerce' ) . '</a>';
-			echo '<a href="' . esc_url( $dismiss_url ) . '" class = "btn dismiss grey" onclick="fb_woo_infobanner_post_xout(); return true;" title="' . __( 'Dismiss this notice.', 'facebook-for-woocommerce' ) . '"> ' . __( 'Dismiss', 'facebook-for-woocommerce' ) . '</a>';
+			echo '<a href="' . esc_url( $tip_action_link ) . '" class = "btn" onclick="fb_woo_infobanner_post_click(); return true;" title="' . esc_attr__( 'Click and redirect.', 'facebook-for-woocommerce' ) . '"> ' . __( $tip_action, 'facebook-for-woocommerce' ) . '</a>';
+			echo '<a href="' . esc_url( $dismiss_url ) . '" class = "btn dismiss grey" onclick="fb_woo_infobanner_post_xout(); return true;" title="' . esc_attr__( 'Dismiss this notice.', 'facebook-for-woocommerce' ) . '"> ' . __( 'Dismiss', 'facebook-for-woocommerce' ) . '</a>';
 			echo '</p></div></div>';
 		}
 


### PR DESCRIPTION
# Summary

This PR fixes a PHPCS issue in `includes/fbinfobanner.php`.

### Story: [CH 25211](https://app.clubhouse.io/skyverge/story/25211/fix-critical-issues-in-includes-fbinfobanner-php)
### Release: #1

## Details

One of the issues was a false positive that is no longe reported as a problem on recent version of WordPress Coding Standards (WPCS).

I submitted a [related PR](https://github.com/skyverge/facebook-for-woocommerce/pull/6) that updates the version we are using of WPCS and PHP Compatibility.

## QA

### Setup

- Configure Facebook for WooCommerce
- Install the [Facebook Pixel Helper](https://chrome.google.com/webstore/detail/facebook-pixel-helper/fdgfkebogiimcoedlicjlajpkdmockpc) Chrome extension:

### Steps

#### Facebook banner shows up

The content of the notice is retrieved using `WC_Facebookcommerce_Graph_API::get_tip_info()`. I stopped getting content after I dismissed the notice the first time, so if you can't see the notice either add the `fb_info_banner_last_best_tip` option to your database with the following content:

```
{"tip_title":{"__html":"Test Title"},"tip_body":{"__html":"Test Body"},"tip_action_link":"https:\/\/google.com","tip_img_url":"/iamge.png","tip_action":{"__html":"Call to Action"}}
```

1. Go to the plugin settings page
    - [x] A banner is shown with the corresponding title, body and action link 
    - [x] The dismiss URL is properly generated with a nonce
    - The image will look broken useing the test data, because the plugin prefixes the URL with facebook.com and I couldn't find a valid path to use

#### PHPCS

1. Run `vendor/bin/phpcs --severity=6 includes/fbinfobanner.php` (may need to run `composer install` to download latest version of WPCS)
    - [x] No issues are reported

## Before merge

- [x] I have confirmed these changes in each supported minor WooCommerce version