### PR TITLE
Fix critical issues in includes/fbwpml.php

### DIFF
--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -75,12 +75,14 @@ if ( ! class_exists( 'WC_Facebook_WPML_Injector' ) ) :
 		 * The section is shown at the bottom of the WPML > Languages settings page.
 		 */
 		public function wpml_support() {
+			/** @var object $sitepress */
 			global $sitepress;
 
 			// there is no nonce to check here and the value of $_GET['page] is being compared against a known and safe string
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			if ( isset( $_GET['page'] ) && false !== strpos( esc_url_raw( wp_unslash( $_GET['page'] ) ), 'languages.php' ) ) {
 
+				/** @var array $active_languages */
 				$active_languages = $sitepress->get_active_languages();
 				$settings         = get_option( self::OPTION );
 

--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -99,8 +99,7 @@ if ( ! class_exists( 'WC_Facebook_WPML_Injector' ) ) :
 						<h3><?php esc_html_e( 'Facebook Visibility', 'facebook-for-woocommerce' ); ?></h3>
 					</div>
 					<div class="wpml-section-content">
-						WooCommerce Products with languages that are selected
-						here will be visible to customers who see your Facebook Shop.
+						<?php esc_html_e( 'WooCommerce Products with languages that are selected here will be visible to customers who see your Facebook Shop.', 'facebook-for-woocommerce' ); ?>
 
 						<div class="wpml-section-content-inner">
 							<form id="icl_fb_woo" name="icl_fb_woo" action="">

--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -103,19 +103,16 @@ if ( ! class_exists( 'WC_Facebook_WPML_Injector' ) ) :
 
 						<div class="wpml-section-content-inner">
 							<form id="icl_fb_woo" name="icl_fb_woo" action="">
-								<?php
-								foreach ( $settings as $language => $set ) {
-									$is_checked = $set === FB_WPML_Language_Status::VISIBLE ?
-									'checked' : '';
-									$str        = '
-									<p><label>
-										<input type="checkbox" id="icl_fb_woo_chk" name="' . $language . '" ' . $is_checked . '>
-										' . $active_languages[ $language ]['native_name'] . '
-									</label></p>
-									';
-									echo $str;
-								}
-								?>
+
+								<?php foreach ( $settings as $language => $set ) : ?>
+									<p>
+										<label>
+											<input type="checkbox" id="icl_fb_woo_chk" name="<?php echo esc_attr( $language ); ?>" <?php checked( $set, FB_WPML_Language_Status::VISIBLE ); ?>>
+											<?php echo esc_html( $active_languages[ $language ]['native_name'] ); ?>
+										</label>
+									</p>
+								<?php endforeach; ?>
+
 								<p class="buttons-wrap">
 									<span class="icl_ajx_response_fb" id="icl_ajx_response_fb" hidden="true">
 									<?php echo $ajax_response; ?>

--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -96,7 +96,7 @@ if ( ! class_exists( 'WC_Facebook_WPML_Injector' ) ) :
 				?>
 				<div id="lang-sec-fb" class="wpml-section wpml-section-languages">
 					<div class="wpml-section-header">
-						<h3><?php _e( 'Facebook Visibility', 'sitepress' ); ?></h3>
+						<h3><?php esc_html_e( 'Facebook Visibility', 'facebook-for-woocommerce' ); ?></h3>
 					</div>
 					<div class="wpml-section-content">
 						WooCommerce Products with languages that are selected

--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -127,7 +127,7 @@ if ( ! class_exists( 'WC_Facebook_WPML_Injector' ) ) :
 									</span>
 									<input class="button button-primary"
 										name="save"
-										value="<?php _e( 'Save', 'sitepress' ); ?>"
+										value="<?php esc_attr_e( 'Save', 'sitepress' ); ?>"
 										type="submit" />
 								</p>
 							</form>

--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -71,6 +71,8 @@ if ( ! class_exists( 'WC_Facebook_WPML_Injector' ) ) :
 		public function wpml_support() {
 			global $sitepress;
 
+			// there is no nonce to check here and the value of $_GET['page] is being compared against a known and safe string
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			if ( isset( $_GET['page'] ) && false !== strpos( esc_url_raw( wp_unslash( $_GET['page'] ) ), 'languages.php' ) ) {
 
 				$active_languages = $sitepress->get_active_languages();

--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -88,7 +88,8 @@ if ( ! class_exists( 'WC_Facebook_WPML_Injector' ) ) :
 
 				// Default setting is only show default lang.
 				if ( ! $settings ) {
-					$settings                        = array_fill_keys(
+
+					$settings = array_fill_keys(
 						array_keys( $active_languages ),
 						FB_WPML_Language_Status::HIDDEN
 					);
@@ -110,12 +111,14 @@ if ( ! class_exists( 'WC_Facebook_WPML_Injector' ) ) :
 							<form id="icl_fb_woo" name="icl_fb_woo" action="">
 
 								<?php foreach ( $settings as $language => $set ) : ?>
+
 									<p>
 										<label>
 											<input type="checkbox" id="icl_fb_woo_chk" name="<?php echo esc_attr( $language ); ?>" <?php checked( $set, FB_WPML_Language_Status::VISIBLE ); ?>>
 											<?php echo isset( $active_languages[ $language ]['native_name'] ) ? esc_html( $active_languages[ $language ]['native_name'] ) : esc_html( $language ); ?>
 										</label>
 									</p>
+
 								<?php endforeach; ?>
 
 								<p class="buttons-wrap">
@@ -127,19 +130,21 @@ if ( ! class_exists( 'WC_Facebook_WPML_Injector' ) ) :
 											'</a>'
 										); ?>
 									</span>
-									<input class="button button-primary"
+									<input
+										class="button button-primary"
 										name="save"
 										value="<?php esc_attr_e( 'Save', 'sitepress' ); ?>"
-										type="submit" />
+										type="submit"
+									/>
 								</p>
 							</form>
 							<script type="text/javascript">
-								addLoadEvent(function(){
-								jQuery('#icl_fb_woo').submit(iclSaveForm);
-								jQuery('#icl_fb_woo').submit(function(){
-									jQuery('#icl_ajx_response_fb').show();
-								});
-								});
+								addLoadEvent( function() {
+									jQuery( '#icl_fb_woo' ).submit( iclSaveForm );
+									jQuery( '#icl_fb_woo' ).submit( function() {
+										jQuery( '#icl_ajx_response_fb' ).show();
+									} );
+								} );
 							</script>
 						</div>
 					</div>

--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -124,8 +124,8 @@ if ( ! class_exists( 'WC_Facebook_WPML_Injector' ) ) :
 								<p class="buttons-wrap">
 									<span class="icl_ajx_response_fb" id="icl_ajx_response_fb" hidden="true">
 										<?php printf(
-											/* translators: 1 - opening link HTML tag, 2 - closing link HTML tag */
-											esc_html( 'Saved. You should now %1$sRe-Sync%2$s your products with Facebook.', 'facebook-for-woocommerce' ),
+											/* translators: Placeholders %1$s - opening link HTML tag, %2$s - closing link HTML tag */
+											esc_html__( 'Saved. You should now %1$sRe-Sync%2$s your products with Facebook.', 'facebook-for-woocommerce' ),
 											sprintf( '<a href="%s">', esc_url( add_query_arg( 'fb_force_resync', 'true', WOOCOMMERCE_FACEBOOK_PLUGIN_SETTINGS_URL ) ) ),
 											'</a>'
 										); ?>

--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -118,7 +118,12 @@ if ( ! class_exists( 'WC_Facebook_WPML_Injector' ) ) :
 
 								<p class="buttons-wrap">
 									<span class="icl_ajx_response_fb" id="icl_ajx_response_fb" hidden="true">
-									<?php echo $ajax_response; ?>
+										<?php printf(
+											/* translators: 1 - opening link HTML tag, 2 - closing link HTML tag */
+											esc_html( 'Saved. You should now %1$sRe-Sync%2$s your products with Facebook.', 'facebook-for-woocommerce' ),
+											sprintf( '<a href="%s">', esc_url( add_query_arg( 'fb_force_resync', 'true', WOOCOMMERCE_FACEBOOK_PLUGIN_SETTINGS_URL ) ) ),
+											'</a>'
+										); ?>
 									</span>
 									<input class="button button-primary"
 										name="save"

--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -108,7 +108,7 @@ if ( ! class_exists( 'WC_Facebook_WPML_Injector' ) ) :
 									<p>
 										<label>
 											<input type="checkbox" id="icl_fb_woo_chk" name="<?php echo esc_attr( $language ); ?>" <?php checked( $set, FB_WPML_Language_Status::VISIBLE ); ?>>
-											<?php echo esc_html( $active_languages[ $language ]['native_name'] ); ?>
+											<?php echo isset( $active_languages[ $language ]['native_name'] ) ? esc_html( $active_languages[ $language ]['native_name'] ) : esc_html( $language ); ?>
 										</label>
 									</p>
 								<?php endforeach; ?>

--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -70,7 +70,9 @@ if ( ! class_exists( 'WC_Facebook_WPML_Injector' ) ) :
 
 		public function wpml_support() {
 			global $sitepress;
-			if ( strpos( $_GET['page'], 'languages.php' ) ) {
+
+			if ( isset( $_GET['page'] ) && false !== strpos( esc_url_raw( wp_unslash( $_GET['page'] ) ), 'languages.php' ) ) {
+
 				$active_languages = $sitepress->get_active_languages();
 				$settings         = get_option( self::OPTION );
 

--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -68,6 +68,12 @@ if ( ! class_exists( 'WC_Facebook_WPML_Injector' ) ) :
 			}
 		}
 
+
+		/**
+		 * Prints the content for Facebook Visibility section.
+		 *
+		 * The section is shown at the bottom of the WPML > Languages settings page.
+		 */
 		public function wpml_support() {
 			global $sitepress;
 
@@ -139,6 +145,8 @@ if ( ! class_exists( 'WC_Facebook_WPML_Injector' ) ) :
 				<?php
 			}
 		}
+
+
 	}
 
 endif;

--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -93,50 +93,51 @@ if ( ! class_exists( 'WC_Facebook_WPML_Injector' ) ) :
 					WOOCOMMERCE_FACEBOOK_PLUGIN_SETTINGS_URL
 				);
 
-				?><div id="lang-sec-fb" class="wpml-section wpml-section-languages">
-		  <div class="wpml-section-header">
-			  <h3><?php _e( 'Facebook Visibility', 'sitepress' ); ?></h3>
-		  </div>
-		  <div class="wpml-section-content">
-			WooCommerce Products with languages that are selected
-			here will be visible to customers who see your Facebook Shop.
-
-			<div class="wpml-section-content-inner">
-			  <form id="icl_fb_woo" name="icl_fb_woo" action="">
-				<?php
-				foreach ( $settings as $language => $set ) {
-					$is_checked = $set === FB_WPML_Language_Status::VISIBLE ?
-					'checked' : '';
-					$str        = '
-                      <p><label>
-                        <input type="checkbox" id="icl_fb_woo_chk" name="' . $language . '" ' . $is_checked . '>
-                        ' . $active_languages[ $language ]['native_name'] . '
-                      </label></p>
-                    ';
-					echo $str;
-				}
 				?>
-			  <p class="buttons-wrap">
-				<span class="icl_ajx_response_fb" id="icl_ajx_response_fb" hidden="true">
-				  <?php echo $ajax_response; ?>
-				</span>
-				<input class="button button-primary"
-					   name="save"
-					   value="<?php _e( 'Save', 'sitepress' ); ?>"
-					   type="submit" />
-			  </p>
-			  </form>
-			  <script type="text/javascript">
-				addLoadEvent(function(){
-				  jQuery('#icl_fb_woo').submit(iclSaveForm);
-				  jQuery('#icl_fb_woo').submit(function(){
-					jQuery('#icl_ajx_response_fb').show();
-				  });
-				});
-			  </script>
-			</div>
-		  </div>
-	  </div>
+				<div id="lang-sec-fb" class="wpml-section wpml-section-languages">
+					<div class="wpml-section-header">
+						<h3><?php _e( 'Facebook Visibility', 'sitepress' ); ?></h3>
+					</div>
+					<div class="wpml-section-content">
+						WooCommerce Products with languages that are selected
+						here will be visible to customers who see your Facebook Shop.
+
+						<div class="wpml-section-content-inner">
+							<form id="icl_fb_woo" name="icl_fb_woo" action="">
+								<?php
+								foreach ( $settings as $language => $set ) {
+									$is_checked = $set === FB_WPML_Language_Status::VISIBLE ?
+									'checked' : '';
+									$str        = '
+									<p><label>
+										<input type="checkbox" id="icl_fb_woo_chk" name="' . $language . '" ' . $is_checked . '>
+										' . $active_languages[ $language ]['native_name'] . '
+									</label></p>
+									';
+									echo $str;
+								}
+								?>
+								<p class="buttons-wrap">
+									<span class="icl_ajx_response_fb" id="icl_ajx_response_fb" hidden="true">
+									<?php echo $ajax_response; ?>
+									</span>
+									<input class="button button-primary"
+										name="save"
+										value="<?php _e( 'Save', 'sitepress' ); ?>"
+										type="submit" />
+								</p>
+							</form>
+							<script type="text/javascript">
+								addLoadEvent(function(){
+								jQuery('#icl_fb_woo').submit(iclSaveForm);
+								jQuery('#icl_fb_woo').submit(function(){
+									jQuery('#icl_ajx_response_fb').show();
+								});
+								});
+							</script>
+						</div>
+					</div>
+				</div>
 				<?php
 			}
 		}

--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -89,12 +89,6 @@ if ( ! class_exists( 'WC_Facebook_WPML_Injector' ) ) :
 						$settings[ self::$default_lang ] = FB_WPML_Language_Status::VISIBLE;
 					}
 				}
-				$ajax_response = sprintf(
-					'Saved. You should now ' .
-					' <a href="%s&fb_force_resync=true">Re-Sync</a>' .
-					' your products with Facebook. ',
-					WOOCOMMERCE_FACEBOOK_PLUGIN_SETTINGS_URL
-				);
 
 				?>
 				<div id="lang-sec-fb" class="wpml-section wpml-section-languages">

--- a/includes/fbwpml.php
+++ b/includes/fbwpml.php
@@ -84,7 +84,10 @@ if ( ! class_exists( 'WC_Facebook_WPML_Injector' ) ) :
 						array_keys( $active_languages ),
 						FB_WPML_Language_Status::HIDDEN
 					);
-					$settings[ self::$default_lang ] = FB_WPML_Language_Status::VISIBLE;
+
+					if ( self::$default_lang ) {
+						$settings[ self::$default_lang ] = FB_WPML_Language_Status::VISIBLE;
+					}
 				}
 				$ajax_response = sprintf(
 					'Saved. You should now ' .


### PR DESCRIPTION
# Summary

This PR fixes a PHPCS issue in `includes/fbwpml.php`.

### Story: [CH 25210](https://app.clubhouse.io/skyverge/story/25210/fix-critical-issues-in-includes-fbwpml-php)
### Release: #1

## Details

The nonce verification on `wpml_support()` is not really an issue because `$_GET['page']` is used in a verification that checks whether it contains the string 'languages' only. I added validation and sanitization, but ignored the nonce verification issue.

https://github.com/skyverge/facebook-for-woocommerce/blob/7ce6a1906392432e3bdd1bebdab9089647e646da/includes/fbwpml.php#L73

Also, the PHPCS ignore comment for that line uses the code of the issue in the latest version of WPCS (See #6).

## QA

### Setup

- Configure Facebook for WooCommerce
- Install and activate WPML

### Steps

#### Facebook Visibility section

1. Go to Dashboard > WPML > Languages
    - [x] There is a Facebook Visibility section at the bottom of the page
    - [x] The section shows a list of the installed languages
1. Click the Save button
    - [x] A success message is shown next to the button
1. Click the Re-Sync link in the success message
    - [x] The link points to the Facebook for WooCommerce settings page
    - [x] An alert informs you that the products will be resynced with Facebook

#### PHPCS

1. Run `vendor/bin/phpcs --severity=6 includes/fbwpml.php`
    - [x] No issues are reported (may need to run `compsoer install` to get the latest version of WPCS)

## Before merge

- [ ] I have confirmed these changes in each supported minor WooCommerce version