### PR TITLE
Improve tracking consistency of AddToCart events

### DIFF
--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -317,23 +317,20 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				die();
 			}
 
-			$fb_product_id = \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product );
-			$fb_pixel      = $this->pixel;
+			$fb_product_id  = \WC_Facebookcommerce_Utils::get_fb_retailer_id( $product );
+			$fb_pixel       = $this->pixel;
+			$fb_pixel_event = $fb_pixel::build_event( 'AddToCart', [
+				'content_ids'  => wp_json_encode( [ $fb_product_id ] ),
+				'content_type' => 'product',
+				'contents'     => wp_json_encode( [
+					'id'       => $fb_product_id,
+					'quantity' => 1,
+				] ),
+				'value'        => $product->get_price(),
+				'currency'     => get_woocommerce_currency(),
+			] );
 
-			wp_send_json(
-				'<script>' .
-					$fb_pixel::build_event( 'AddToCart', [
-						'content_ids'  => wp_json_encode( [ $fb_product_id ] ),
-						'content_type' => 'product',
-						'contents'     => wp_json_encode( [
-							'id'      => $fb_product_id,
-							'quantity'=> 1,
-						] ),
-						'value'        => $product->get_price(),
-						'currency'     => get_woocommerce_currency(),
-					] ) .
-				'</script>'
-			);
+			wp_send_json( '<script>' . $fb_pixel_event . '</script>' );
 		}
 
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -365,7 +365,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 */
 		public function inject_add_to_cart_redirect_event() {
 
-			// bail if Pixel tracking disabled, not on cart page or not using redirect after adding to cart
+			// bail if Pixel tracking disabled or not using redirect after adding to cart
 			if ( ! self::$isEnabled || 'yes' !== get_option( 'woocommerce_cart_redirect_after_add' ) ) {
 				return;
 			}

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -298,10 +298,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 * @see \WC_Facebookcommerce_Pixel::pixel_base_code()
 		 *
 		 * @internal
-		 *
-		 * @param int $product_id
 		 */
-		public function inject_ajax_add_to_cart_event( $product_id = 0 ) {
+		public function inject_ajax_add_to_cart_event() {
 
 			$product_id = isset( $_REQUEST['product_id'] ) ? (int) $_REQUEST['product_id'] : 0;
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -283,7 +283,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				'content_type' => 'product',
 				'contents'     => wp_json_encode( [
 					'id'      => $fb_product_id,
-					'quantity'=> $quantity,
+					'quantity' => $quantity,
 				] ),
 				'value'        => $product->get_price(),
 				'currency'     => get_woocommerce_currency(),

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -281,9 +281,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				'content_type' => 'product',
 				'contents'     => wp_json_encode( [
 					'id'      => $fb_product_id,
-					'quantity'=> (int) $quantity,
+					'quantity'=> $quantity,
 				] ),
-				'value'        => (float) $product->get_price(),
+				'value'        => $product->get_price(),
 				'currency'     => get_woocommerce_currency(),
 			] );
 		}

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -233,8 +233,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				return;
 			}
 
-			// if product is variable, fire the pixel with content_type: product_group
-			if ( $product->is_type( 'variable' ) ) {
+			// if product is variable or grouped, fire the pixel with content_type: product_group
+			if ( $product->is_type( [ 'variable', 'grouped' ] ) ) {
 				$content_type = 'product_group';
 			} else {
 				$content_type = 'product';

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -282,7 +282,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				'content_ids'  => wp_json_encode( [ $fb_product_id ] ),
 				'content_type' => 'product',
 				'contents'     => wp_json_encode( [
-					'id'      => $fb_product_id,
+					'id'       => $fb_product_id,
 					'quantity' => $quantity,
 				] ),
 				'value'        => $product->get_price(),

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -219,18 +219,22 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		 * Triggers ViewContent product pages
 		 */
 		public function inject_view_content_event() {
+			global $post;
+
 			if ( ! self::$isEnabled ) {
 				return;
 			}
-			global $post;
-			$product      = wc_get_product( $post->ID );
-			$content_type = 'product_group';
-			if ( ! $product ) {
+
+			$product = wc_get_product( $post->ID );
+
+			if ( ! $product instanceof \WC_Product ) {
 				return;
 			}
 
 			// if product is a variation, fire the pixel with content_type: product_group
 			if ( \WC_Facebookcommerce_Utils::is_variation_type( $product->get_type() ) ) {
+				$content_type = 'product_group';
+			} else {
 				$content_type = 'product';
 			}
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -52,11 +52,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				array( $this, 'inject_search_event' )
 			);
 
-			add_action( 'woocommerce_after_cart', array( $this, 'inject_add_to_cart_redirect_event' ) );
-
 			add_action( 'woocommerce_add_to_cart', array( $this, 'inject_add_to_cart_event' ), 100 );
-
-			add_action( 'wc_ajax_fb_inject_add_to_cart_event', array( $this, 'inject_ajax_add_to_cart_event' ), self::FB_PRIORITY_HIGH );
 
 			add_action(
 				'woocommerce_after_checkout_form',
@@ -290,49 +286,28 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 		/**
 		 * Sends a JSON response with the JavaScript code to track an AddToCart event.
 		 *
-		 * Handler for the fb_inject_add_to_cart_event WC Ajax action.
+		 * @internal
+		 * @deprecated
 		 */
 		public function inject_ajax_add_to_cart_event() {
 
-			if ( ! self::$isEnabled ) {
-				return;
-			}
-
-			$event_params = [
-				'content_ids'  => json_encode( $this->get_content_ids_from_cart( WC()->cart->get_cart() ) ),
-				'content_type' => 'product',
-				'value'        => WC()->cart->total,
-				'currency'     => get_woocommerce_currency(),
-			];
-
-			ob_start();
-
-			echo '<script>';
-
-			// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-			echo $this->pixel->build_event( 'AddToCart', $event_params );
-
-			echo '</script>';
-
-			$pixel = ob_get_clean();
-
-			wp_send_json( $pixel );
+			// TODO remove this deprecated method in a future release {FN 2020-01-07}
+			wc_deprecated_function( __METHOD__, '2.0.0' );
 		}
+
 
 		/**
 		 * Trigger AddToCart for cart page and woocommerce_after_cart hook.
-		 * When set 'redirect to cart', ajax call for button click and
-		 * woocommerce_add_to_cart will be skipped.
+		 *
+		 * @internal
+		 * @deprecated
 		 */
 		public function inject_add_to_cart_redirect_event() {
-			if ( ! self::$isEnabled ) {
-				return;
-			}
-			$redirect_checked = get_option( 'woocommerce_cart_redirect_after_add', 'no' );
-			if ( $redirect_checked == 'yes' ) {
-				$this->inject_add_to_cart_event();
-			}
+
+			// TODO remove this deprecated method in a future release {FN 2020-01-07}
+			wc_deprecated_function( __METHOD__, '2.0.0' );
 		}
+
 
 		/**
 		 * Triggers InitiateCheckout for checkout page

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -52,7 +52,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				array( $this, 'inject_search_event' )
 			);
 
-			add_action( 'woocommerce_add_to_cart', array( $this, 'inject_add_to_cart_event' ), 100 );
+			add_action( 'woocommerce_add_to_cart', [ $this, 'inject_add_to_cart_event' ], 100, 4 );
 
 			add_action(
 				'woocommerce_after_checkout_form',

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -229,22 +229,18 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				return;
 			}
 
-			// if product is a variant, fire the pixel with content_type: product_group
-			if ( WC_Facebookcommerce_Utils::is_variation_type( $product->get_type() ) ) {
+			// if product is a variation, fire the pixel with content_type: product_group
+			if ( \WC_Facebookcommerce_Utils::is_variation_type( $product->get_type() ) ) {
 				$content_type = 'product';
 			}
 
-			$content_ids = WC_Facebookcommerce_Utils::get_fb_content_ids( $product );
-			$this->pixel->inject_event(
-				'ViewContent',
-				array(
-					'content_name' => $product->get_title(),
-					'content_ids'  => json_encode( $content_ids ),
-					'content_type' => $content_type,
-					'value'        => $product->get_price(),
-					'currency'     => get_woocommerce_currency(),
-				)
-			);
+			$this->pixel->inject_event( 'ViewContent', [
+				'content_name' => $product->get_title(),
+				'content_ids'  => wp_json_encode( \WC_Facebookcommerce_Utils::get_fb_content_ids( $product ) ),
+				'content_type' => $content_type,
+				'value'        => $product->get_price(),
+				'currency'     => get_woocommerce_currency(),
+			] );
 		}
 
 

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -232,8 +232,8 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				return;
 			}
 
-			// if product is a variation, fire the pixel with content_type: product_group
-			if ( \WC_Facebookcommerce_Utils::is_variation_type( $product->get_type() ) ) {
+			// if product is variable, fire the pixel with content_type: product_group
+			if ( $product->is_type( 'variable' ) ) {
 				$content_type = 'product_group';
 			} else {
 				$content_type = 'product';

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -38,11 +38,9 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				'wp_footer',
 				array( $this, 'inject_base_pixel_noscript' )
 			);
-			add_action(
-				'woocommerce_after_single_product',
-				array( $this, 'inject_view_content_event' ),
-				self::FB_PRIORITY_HIGH
-			);
+
+			add_action( 'woocommerce_after_single_product', [ $this, 'inject_view_content_event' ] );
+
 			add_action(
 				'woocommerce_after_shop_loop',
 				array( $this, 'inject_view_category_event' )
@@ -215,8 +213,11 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 			return $product_ids;
 		}
 
+
 		/**
-		 * Triggers ViewContent product pages
+		 * Triggers ViewContent event on product pages
+		 *
+		 * @internal
 		 */
 		public function inject_view_content_event() {
 			global $post;

--- a/facebook-commerce-events-tracker.php
+++ b/facebook-commerce-events-tracker.php
@@ -39,6 +39,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				array( $this, 'inject_base_pixel_noscript' )
 			);
 
+			// ViewContent for individual products
 			add_action( 'woocommerce_after_single_product', [ $this, 'inject_view_content_event' ] );
 
 			add_action(
@@ -50,7 +51,7 @@ if ( ! class_exists( 'WC_Facebookcommerce_EventsTracker' ) ) :
 				array( $this, 'inject_search_event' )
 			);
 
-			// add to cart events
+			// AddToCart
 			add_action( 'woocommerce_add_to_cart',             [ $this, 'inject_add_to_cart_event' ], 10, 4 );
 			add_filter( 'woocommerce_add_to_cart_redirect',    [ $this, 'set_last_product_added_to_cart_upon_redirect' ], 10, 2 );
 			add_action( 'template_redirect',                   [ $this, 'inject_add_to_cart_redirect_event'] );

--- a/facebook-commerce-pixel-event.php
+++ b/facebook-commerce-pixel-event.php
@@ -93,18 +93,17 @@ document,'script','https://connect.facebook.net/en_US/fbevents.js');
 %s
 <script>
 %s
-fbq('track', 'PageView', %s);
+fbq( 'track', 'PageView', %s );
 
-document.addEventListener('DOMContentLoaded', function() {
-  jQuery && jQuery(function($){
-    $('body').on('added_to_cart', function(event) {
-      // Ajax action.
-      $.get('?wc-ajax=fb_inject_add_to_cart_event', function(data) {
-        $('head').append(data);
-      });
-    });
-  });
-}, false);
+document.addEventListener( 'DOMContentLoaded', function() {
+	jQuery && jQuery( function( $ ) {
+		$( '.add_to_cart_button' ).on( 'click', function( e ) {
+			$.get( '?wc-ajax=fb_inject_add_to_cart_event&product_id=' + $( this ).data( 'product_id' ), function( script ) {
+				$( 'head' ).append( script );
+			} );
+		} );
+	} );
+}, false );
 
 </script>
 <!-- DO NOT MODIFY -->


### PR DESCRIPTION
# Summary

Some customers reported some inconsistencies when Facebook Pixel events should be tracked, and this PR tries to address some of those related to when a product is  added to cart.

### Story [ch25109](https://app.clubhouse.io/skyverge/story/25109/pixel-not-correctly-tracking-events)

## Additional Details

_Unfortunately we don't have access to any of the customers websites when further debugging would be helpful. It's likely that some events that the plugin listens to could be disrupted by particular themes or third party plugins. On the other hand, code inspection and some of the customer feedback is helpful enough to pin point some of the most obvious cases._

There's one peculiarity with how Facebook Pixel triggers events and that is that some JS code needs to printed on the page. When the AJAX add to cart button is enabled on WC sites, the page is not redirected to cart nor reloaded, making the add to cart the event not detected. This was addressed in the original plugin code by adding a listener to the [`added_to_cart`](https://github.com/facebookincubator/facebook-for-woocommerce/blob/master/facebook-commerce-pixel-event.php#L100) WC event, but it looks like this could produce duplicate entries. A better approach could be to monitor click events to `.add_to_cart_button` since the button on single pages is `.single_add_to_cart_button`. This class should be pretty ubiquitous in WooCommerce compatible themes and should be reasonably safe to use. 

Yet another peculiarity is that the plugin code added [all items in cart](https://github.com/facebookincubator/facebook-for-woocommerce/blob/master/facebook-commerce-events-tracker.php#L326) to the data sent to FB each time one such `AddToCart` event was triggered, including when listening to the more straightforward `woocommerce_add_to_cart` action hook. This PR changes this so that only the current cart item being effectively added is tracked (and its quantity, previously untracked). Another inconsistency with this was that the plugin would have sent the total value of the cart items to Facebook. However, the plugin also hooked to `woocommerce_add_to_cart` with a timing before [WooCommerce would have updated the totals](https://github.com/facebookincubator/facebook-for-woocommerce/issues/846).

The former code also added one specific handling for when the add to cart button should be redirecting to the cart. This used to listen to `woocommerce_after_cart` hook, which is typically on the cart page (but I get on some themes could be produced elsewhere); furthermore the code would always add all the items to cart, as highlighted above. But this could have resulted in sending all items at all times in some circumstances. The new handling proposes to store the last item added to cart to session when `woocommerce_add_to_cart_redirect` is triggered, then upon page load look for that information, inject the add to cart event, and delete that session information. In theory `woocommerce_add_to_cart_redirect` could redirect to any page after adding to cart, therefore we should listen for the last item added to cart while on any page. 

The JSON data sent to FB also did not include the `contents` attribute, but this attribute seems to be listed as [required for dynamic ads](https://developers.facebook.com/docs/facebook-pixel/reference). This PR adds that.

## UI changes

None.

## QA

### Setup

- Have the plugin configured and some product synced.
- Verify that Pixel is loaded on shop pages with the Chrome extension.
- You will change the Add to cart behaviour in WooCommerce > Settings > Products a few times for the cases listed below
- Keep track of the events with `https://www.facebook.com/events_manager/pixel/verify?...` (the Chrome extension should give you the right URL for this for your account)

**Important Note:** especially for AJAX events, you should check on the events manager page whether an event has been recorded; this is because the code to track the event is added on the original page, in case you visit or are redirected to the cart page later, therefore when you load that page the add to cart event is not there, but there should be a record in the events manager. 

### Cases

#### View product

I should have probably filed this in a different PR, but I got carried away: I noticed that [here](https://github.com/facebookincubator/facebook-for-woocommerce/blob/master/facebook-commerce-events-tracker.php#L226-L236) the `product_type` is wrong and should be `product_group` when the viewed product is a variable or a group, not a individual variation. 

- [ ] When viewing a simple product, `product` should be the `content_type` sent to Facebook
- [ ] When viewing a variable product or a grouped product, `product_group` should be the `content_type` sent to Facebook

#### Add to cart behaviour: no redirection, no AJAX

- [ ] Settings: disable `Redirect to the cart page after successful addition`
- [ ] Settings: disable `Enable AJAX add to cart buttons on archives`
- [ ] Add product to cart from the _Shop_ page: event should be recorded
- [ ] Add product to cart from the _Product_ page: event should be recorded
- [ ] Try again with a variable product from the _Product_ page: event should be recorded with the correct product variation

#### Add to cart behaviour: enable AJAX add to cart

- [ ] Settings: enable `Enable AJAX add to cart buttons on archives`
- [ ] Add product to cart from the _Shop_ page: event should be recorded without leaving the page / no page reload occurring
- [ ] Add product to cart from the _Product_ page: event should be recorded
- [ ] Try again with a variable product from the _Product_ page: event should be recorded with the correct product variation

#### Add to cart behaviour: enable redirect to cart

- [ ] Settings: enable `Redirect to the cart page after successful addition`
- [ ] Add product to cart from the _Shop_ page: event should be recorded upon redirection
- [ ] Add product to cart from the _Product_ page: event should be recorded upon redirection
- [ ] Try again with a variable product from the _Product_ page: event should be recorded with the correct product variation

#### All cases when adding to cart

- [ ] The sent data should be similar to the following:

```json
{
	"content_type": "product"
	"content_ids": [ "wc_post_id_19" ]
	"value": 10
	"source": "woocommerce"
	"contents": 
	{
			"id": "wc_post_id_19",
			"quantity": 1 
	}
	"pluginVersion": "1.9.15"
	"currency": "USD"
	"version": "3.9.0"
}
```

## Resources

Tickets potentially addressed by this PR:

 - [846](https://github.com/facebookincubator/facebook-for-woocommerce/issues/846): `value` equals to 0 because hook timing is wrong and cart totals aren't calculated
 - [1152](https://github.com/facebookincubator/facebook-for-woocommerce/issues/1152) and possibly [1155](https://github.com/facebookincubator/facebook-for-woocommerce/issues/1155): `AddToCart` firing twice (likely theme related, possibly interacting with `added_to_cart`)
 - [1133](https://github.com/facebookincubator/facebook-for-woocommerce/issues/1133), [877](https://github.com/facebookincubator/facebook-for-woocommerce/issues/877) and [815](https://github.com/facebookincubator/facebook-for-woocommerce/issues/815): no `AddToCart` event recorded (hard to tell why, maybe `added_to_cart` or other hook not triggering)
 - [869](https://github.com/facebookincubator/facebook-for-woocommerce/issues/869): Add to Cart firing on all pages: possibly because of redirection hook callback listener with `woocommerce_after_cart`
 - [1118](https://github.com/facebookincubator/facebook-for-woocommerce/issues/1118): issue related to retargeting and product_group type
- [950](https://github.com/facebookincubator/facebook-for-woocommerce/issues/950) also product group related, mismatched ID due to view event filing as `product` and not `product_group`