### PR TITLE
Sync meta tweaks

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -127,18 +127,18 @@ class Admin {
 
 				$query_vars['meta_query']['relation'] = 'OR';
 				$query_vars['meta_query'][]           = [
-					'key'   => '_wc_facebook_sync',
+					'key'   => Products::SYNC_ENABLED_META_KEY,
 					'value' => 'yes',
 				];
 				$query_vars['meta_query'][]           = [
-					'key'     => '_wc_facebook_sync',
+					'key'     => Products::SYNC_ENABLED_META_KEY,
 					'compare' => 'NOT EXISTS',
 				];
 
 			} else {
 
 				$query_vars['meta_query'][] = [
-					'key'   => '_wc_facebook_sync',
+					'key'   => Products::SYNC_ENABLED_META_KEY,
 					'value' => 'no',
 				];
 			}

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -21,7 +21,7 @@ class Products {
 
 
 	/** @var string the meta key used to flag whether a product should be synced in Facebook */
-	const SYNC_ENABLED_META_KEY = '_wc_facebook_sync';
+	const SYNC_ENABLED_META_KEY = '_wc_facebook_sync_enabled';
 
 
 	/**

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -21,7 +21,7 @@ class Products {
 
 
 	/** @var string the meta key used to flag whether a product should be synced in Facebook */
-	const SYNC_META_KEY = '_wc_facebook_sync';
+	const SYNC_ENABLED_META_KEY = '_wc_facebook_sync';
 
 
 	/**
@@ -40,7 +40,7 @@ class Products {
 
 			if ( $product instanceof \WC_Product ) {
 
-				$product->update_meta_data( self::SYNC_META_KEY, $meta_value );
+				$product->update_meta_data( self::SYNC_ENABLED_META_KEY, $meta_value );
 				$product->save_meta_data();
 			}
 		}
@@ -88,7 +88,7 @@ class Products {
 	 */
 	public static function is_sync_enabled_for_product( \WC_Product $product ) {
 
-		return 'no' !== $product->get_meta( self::SYNC_META_KEY );
+		return 'no' !== $product->get_meta( self::SYNC_ENABLED_META_KEY );
 	}
 
 

--- a/includes/Products.php
+++ b/includes/Products.php
@@ -34,13 +34,11 @@ class Products {
 	 */
 	private static function set_sync_for_products( array $products, $enabled ) {
 
-		$meta_value = $enabled ? 'yes' : 'no';
-
 		foreach ( $products as $product ) {
 
 			if ( $product instanceof \WC_Product ) {
 
-				$product->update_meta_data( self::SYNC_ENABLED_META_KEY, $meta_value );
+				$product->update_meta_data( self::SYNC_ENABLED_META_KEY, wc_bool_to_string( $enabled ) );
 				$product->save_meta_data();
 			}
 		}


### PR DESCRIPTION
# Summary

Tweaks the naming to better match where we ended up on the UI.

### Story: [CH 26638](https://app.clubhouse.io/facebookforwoocommerce/story/26638)
### Release: #12

## Details

* Updates the constant and meta key naming for consistency
* Uses the constant in other areas to avoid hardcoding the meta key name
* Uses the core API function for converting the `$enabled` bool to `yes|no` meta value

## UI Changes

_Nope!_

## QA

- [ ] Integration tests pass